### PR TITLE
Allow to disable a running instance

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -81,7 +81,8 @@
         delimiterChar: ',',
         delimiterKeyCode: 188,
         processData: null,
-        onError: null
+        onError: null,
+        enabled: true
     };
 
     /**
@@ -500,6 +501,7 @@
      * Set timeout to activate autocompleter
      */
     $.Autocompleter.prototype.activate = function() {
+        if (!this.options.enabled) return;
         var self = this;
         if (this.keyTimeout_) {
             clearTimeout(this.keyTimeout_);


### PR DESCRIPTION
By setting options.enabled to `false`, an instance does not activate
anymore (but still deactivates if open at the time of disabling).

Only usefull by providing a way to change options of a running instance
(see other pull request).
