### PR TITLE
add 'disabled' option

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -80,7 +80,8 @@
         delimiterChar: ',',
         delimiterKeyCode: 188,
         processData: null,
-        onError: null
+        onError: null,
+        disabled: false
     };
 
     /**
@@ -323,6 +324,9 @@
          * Attach keyboard monitoring to $elem
          */
         $elem.keydown(function(e) {
+            if (self.options.disabled) {
+                return;
+            }
             self.lastKeyPressed_ = e.keyCode;
             switch(self.lastKeyPressed_) {
 


### PR DESCRIPTION
For a current project, I have a need to disable/reenable the autocomplete. I addressed this the easiest way I could think of, by adding an option and short-circuiting the `keydown` if it was set. It looks like the option can be modified via `$('input').data('autocompleter').options.disabled = true`.

I didn't compile the minified file because I wasn't 100% sure you'd want to tackle this in the same way (if at all), but that'd be easy to add.
