### PR TITLE
Fix of the "beforeUseConverter" and "getValue" methods signatures

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -780,15 +780,13 @@
 
     /**
      * Convert string before use
-     * @param s
-     * @param a
-     * @param b
+     * @param {String} s
      */
-    $.Autocompleter.prototype.beforeUseConverter = function(s, a, b) {
-        s = this.getValue();
+    $.Autocompleter.prototype.beforeUseConverter = function(s) {
+        s = this.getValue(s);
         var converter = this.options.beforeUseConverter;
         if ($.isFunction(converter)) {
-            s = converter(s, a, b);
+            s = converter(s);
         }
         return s;
     };
@@ -1104,13 +1102,12 @@
      * Get the value currently being autocompleted
      * @param {String} value
      */
-    $.Autocompleter.prototype.getValue = function() {
-        var val = this.dom.$elem.val();
+    $.Autocompleter.prototype.getValue = function(value) {
         if ( this.options.useDelimiter ) {
             var d = this.getDelimiterOffsets();
-            return val.substring(d.start, d.end).trim();
+            return value.substring(d.start, d.end).trim();
         } else {
-            return val;
+            return value;
         }
     };
 


### PR DESCRIPTION
The method `beforeUseConverter` has never used its parameters.  
The method `getValue` was designed to use an input string but instead it always has used `this.dom.$el.val()`.
