### PR TITLE
Prolonged mouse click issue fixed

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -822,7 +822,7 @@
         var self = this;
         var $li = $('<li>' + this.showResult(result.value, result.data) + '</li>');
         $li.data({value: result.value, data: result.data})
-            .click(function() {
+            .mousedown(function() {
                 self.selectItem($li);
             })
             .mousedown(self.disableFinishOnBlur)


### PR DESCRIPTION
Amended createItemFromResult to fire on mousedown rather than click, preventing a prolonged mouse click from hiding the autocomplete dropdown and not updating the text input.
