### PR TITLE
2 implied globals put in scope

### DIFF
--- a/src/jquery.autocomplete.js
+++ b/src/jquery.autocomplete.js
@@ -1132,11 +1132,12 @@
      */
     $.Autocompleter.prototype.getDelimiterOffsets = function() {
         var val = this.dom.$elem.val();
+        var start, end;
         if ( this.options.useDelimiter ) {
             var preCaretVal = val.substring(0, this.getCaret().start);
-            var start = preCaretVal.lastIndexOf(this.options.delimiterChar) + 1;
             var postCaretVal = val.substring(this.getCaret().start);
-            var end = postCaretVal.indexOf(this.options.delimiterChar);
+            start = preCaretVal.lastIndexOf(this.options.delimiterChar) + 1;
+            end = postCaretVal.indexOf(this.options.delimiterChar);
             if ( end == -1 ) end = val.length;
             end += this.getCaret().start;
         } else {


### PR DESCRIPTION
Lines 1143-4 start and end vars are not defined.

Move the variable declarations to the beginning of the function to stop them from becoming globals.  

No compiled js because of anticipated conflicts with other Pull requests.
